### PR TITLE
CI against Ruby 2.4.9, 2.5.7, 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ before_install:
   - gem install bundler -v 1.17.3
 
 rvm:
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 script:
   - bundle exec rspec spec


### PR DESCRIPTION
CI against Ruby 2.4.9, 2.5.7, 2.6.5

https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/